### PR TITLE
Fix Firefox 52 ESR compatibility

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -2,17 +2,13 @@ function ff2mpv(url) {
     browser.runtime.sendNativeMessage("ff2mpv", { url: url });
 }
 
-browser.menus.create({
+browser.contextMenus.create({
     id: "ff2mpv",
     title: "Play in MPV",
-    contexts: ["link"],
-    icons: {
-        "16": "icons/icon_16x16.png",
-        "32": "icons/icon_32x32.png",
-    },
+    contexts: ["link"]
 });
 
-browser.menus.onClicked.addListener((info, tab) => {
+browser.contextMenus.onClicked.addListener((info, tab) => {
     switch (info.menuItemId) {
         case "ff2mpv":
             ff2mpv(info.linkUrl);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "description": "Tries to play links in MPV",
     "manifest_version": 2,
     "name": "ff2mpv",
-    "version": "2.1",
+    "version": "2.2",
 
     "icons": {
         "16": "icons/icon_16x16.png",
@@ -28,5 +28,5 @@
         "scripts": ["ff2mpv.js"]
     },
 
-    "permissions": ["nativeMessaging", "contextMenus", "menus", "activeTab"]
+    "permissions": ["nativeMessaging", "contextMenus", "activeTab"]
 }


### PR DESCRIPTION
Currently your addon doesn't work on Firefox 52 ESR because `browser.menus` is FF55+ and `icons` object is FF56+ ([source](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/create)). I'm not sure why you'd want to use `icons` object, since I've tested (on FF52 and FF57) and icon is present in context menu even without it.