### PR TITLE
Launch mpv with VAAPI

### DIFF
--- a/ff2mpv
+++ b/ff2mpv
@@ -6,5 +6,5 @@ require "json"
 len = STDIN.read(4).unpack1("L")
 url = JSON.parse(STDIN.read(len))["url"]
 
-pid = spawn "mpv", "--no-terminal", "--", url, in: :close, out: "/dev/null", err: "/dev/null"
+pid = spawn "mpv", "--no-terminal", "hwdec=vaapi", "vo=gpu", "--", url, in: :close, out: "/dev/null", err: "/dev/null"
 Process.detach pid

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -5,7 +5,7 @@ from subprocess import Popen, DEVNULL
 def main():
     message = get_message()
     url = message.get('url')
-    args = ['mpv', '--no-terminal', '--', url]
+    args = ['mpv', '--no-terminal', 'hwdec=vaapi', 'vo=gpu', '--', url]
     Popen(args, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
     # Need to respond something to avoid "Error: An unexpected error occurred"
     # in Browser Console.


### PR DESCRIPTION
One of the big reasons to use mpv over Firefox is hardware decoding. I've changed the mpv launch command to launch with VA-API. I've only tested this on Linux so I don't know how mpv will handle this on other platforms.