### PR TITLE
Pass site cookies to mpv

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -1,5 +1,14 @@
 function ff2mpv(url) {
-    browser.runtime.sendNativeMessage("ff2mpv", { url: url });
+    browser.cookies.getAll({
+        url: url
+    }).then(
+        function(sitecookies) {
+            browser.runtime.sendNativeMessage("ff2mpv", {
+                url: url,
+                cookies: sitecookies
+            });
+        }
+    )
 }
 
 browser.contextMenus.create({

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -1,4 +1,4 @@
-function ff2mpv(url) {
+function ff2mpv_cookies(url) {
     browser.cookies.getAll({
         url: url
     }).then(
@@ -11,9 +11,21 @@ function ff2mpv(url) {
     )
 }
 
+function ff2mpv(url) {
+    browser.runtime.sendNativeMessage("ff2mpv", {
+	    url: url
+    });
+}
+
 browser.contextMenus.create({
     id: "ff2mpv",
     title: "Play in MPV",
+    contexts: ["link", "image", "video", "audio", "selection", "frame"]
+});
+
+browser.contextMenus.create({
+    id: "ff2mpv_cookies",
+    title: "Play in MPV (Cookies)",
     contexts: ["link", "image", "video", "audio", "selection", "frame"]
 });
 
@@ -25,6 +37,14 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
             */
             url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
             if (url) ff2mpv(url);
+            break;
+
+        case "ff2mpv_cookies":
+            /* These should be mutually exclusive, but,
+               if they aren't, this is a reasonable priority.
+            */
+            url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
+            if (url) ff2mpv_cookies(url);
             break;
     }
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -1,19 +1,7 @@
-function ff2mpv_cookies(url) {
-    browser.cookies.getAll({
-        url: url
-    }).then(
-        function(sitecookies) {
-            browser.runtime.sendNativeMessage("ff2mpv", {
-                url: url,
-                cookies: sitecookies
-            });
-        }
-    )
-}
-
-function ff2mpv(url) {
+function ff2mpv(url, cookies={}) {
     browser.runtime.sendNativeMessage("ff2mpv", {
-	    url: url
+        url: url,
+        cookies: cookies
     });
 }
 
@@ -44,7 +32,11 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
                if they aren't, this is a reasonable priority.
             */
             url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
-            if (url) ff2mpv_cookies(url);
+            if (url) {
+                browser.cookies.getAll({url: url}).then((cookies) => {
+                    ff2mpv(url, cookies);
+                });
+            }
             break;
     }
 });

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -11,18 +11,19 @@ def main():
     message = get_message()
 
     url = message.get('url')
+    ytdloptions = {}
+    additional_mpv_args = []
 
-    cookies_fname = create_cookiefile(message.get('cookies'));
+    if "cookies" in message:
+        cookies_fname = create_cookiefile(message.get("cookies"));
+        ytdloptions["cookies"] = cookies_fname
+        additional_mpv_args += ['--cookies', '--cookies-file={}'.format(cookies_fname)]
 
-    ytdloptions = {
-        "cookies" : cookies_fname
-    }
     mpv_ytdloptions = '--ytdl-raw-options={}'.format(
         ",".join("{}={}".format(k,v) for k,v in ytdloptions.items()))
 
-    args = ['mpv', '--no-terminal',
-            '--cookies', '--cookies-file={}'.format(cookies_fname),
-            mpv_ytdloptions, '--', url]
+    args = ['mpv', '--no-terminal', mpv_ytdloptions] + additional_mpv_args + ["--", url]
+
 
     Popen(args, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
 

--- a/manifest.json
+++ b/manifest.json
@@ -37,5 +37,11 @@
         "scripts": ["ff2mpv.js"]
     },
 
-    "permissions": ["nativeMessaging", "contextMenus", "activeTab"]
+    "permissions": [
+        "nativeMessaging",
+        "contextMenus",
+        "activeTab",
+        "cookies",
+        "<all_urls>"
+    ]
 }


### PR DESCRIPTION
This change would implement #19. I only updated the python script as I am unfamiliar with ruby.
The extension will request two new permissions:
1. _<all_urls>_ host permission
2. _cookies_

I believe that this is not a problem as the extension is running a script with filesystem and network access anyways.

Closes #19.