### PR TITLE
Add windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
           pip install flake8 black
       - name: lint
         run: |
-          black --check ff2mpv.py
-          flake8 ff2mpv.py
+          black --check ff2mpv.py check-config-win.py
+          flake8 ff2mpv.py check-config.win.py
   lint-js:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: lint
         run: |
           black --check ff2mpv.py check-config-win.py
-          flake8 ff2mpv.py check-config.win.py
+          flake8 ff2mpv.py check-config-win.py
   lint-js:
     runs-on: ubuntu-latest
     steps:

--- a/check-config-win.py
+++ b/check-config-win.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env/python3
 '''
 A Python script that attempts to check that the configuration of your
 nativeMessaging app is set up correctly

--- a/check-config-win.py
+++ b/check-config-win.py
@@ -10,7 +10,6 @@ script.
 """
 import json
 import os
-import re
 import winreg
 
 key_path = "Software\\Mozilla\\NativeMessagingHosts\\ff2mpv"

--- a/check-config-win.py
+++ b/check-config-win.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env/python3
-'''
+"""
 A Python script that attempts to check that the configuration of your
 nativeMessaging app is set up correctly
 
@@ -7,59 +7,59 @@ Currently requires Python 3.
 
 If you find more issues with setting this up, let's see if we can add to this
 script.
-'''
+"""
 import json
 import os
 import re
 import winreg
 
-key_path = 'Software\\Mozilla\\NativeMessagingHosts\\ff2mpv'
+key_path = "Software\\Mozilla\\NativeMessagingHosts\\ff2mpv"
 # Assuming current user overrides local machine.
-key_roots = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE']
+key_roots = ["HKEY_CURRENT_USER", "HKEY_LOCAL_MACHINE"]
 
 found_key = False
 
 for root in key_roots:
     key = winreg.OpenKey(getattr(winreg, root), key_path)
     try:
-        print('Checking:', root, key_path)
-        res = winreg.QueryValueEx(key, '')
+        print("Checking:", root, key_path)
+        res = winreg.QueryValueEx(key, "")
     except FileNotFoundError:
-        print('...error finding key')
+        print("...error finding key")
         continue
 
     found_key = True
     break
 
 if not found_key:
-    raise ValueError('Could not find a registry entry, aborting.')
+    raise ValueError("Could not find a registry entry, aborting.")
 
 json_path = res[0]
-print('Path from registry key is:', json_path)
+print("Path from registry key is:", json_path)
 if not os.path.exists(json_path):
-    raise ValueError('JSON file does not exist:', json_path)
+    raise ValueError("JSON file does not exist:", json_path)
 
 try:
-    bat_data = json.load(open(json_path, 'r'))
+    bat_data = json.load(open(json_path, "r"))
 except json.decoder.JSONDecodeError:
-    raise ValueError('Parsing error. Is {} a JSON file?'.format(json_path))
+    raise ValueError("Parsing error. Is {} a JSON file?".format(json_path))
 
-bat_path = bat_data['path']
-print('Path from JSON is:', bat_path)
+bat_path = bat_data["path"]
+print("Path from JSON is:", bat_path)
 if not os.path.exists(bat_path):
-    raise ValueError('.bat does not exist:', bat_path)
+    raise ValueError(".bat does not exist:", bat_path)
 
-py_lines = open(bat_path, 'r').readlines()
+py_lines = open(bat_path, "r").readlines()
 py_path = None
 for line in py_lines:
-    if line.startswith('call python '):
-        py_path = line[12:].replace('\\\\', '\\').strip()
+    if line.startswith("call python "):
+        py_path = line[12:].replace("\\\\", "\\").strip()
 
 if not py_path:
-    raise ValueError('No python script in the batch file.')
+    raise ValueError("No python script in the batch file.")
 
-print('Path from batch file is:', py_path)
+print("Path from batch file is:", py_path)
 if not os.path.exists(py_path):
-    raise ValueError('Python file does not exist:', py_path)
+    raise ValueError("Python file does not exist:", py_path)
 
-print('Looks good! Give it a try from Firefox.')
+print("Looks good! Give it a try from Firefox.")

--- a/check_config_win.py
+++ b/check_config_win.py
@@ -1,0 +1,64 @@
+'''
+A Python script that attempts to check that the configuration of your
+nativeMessaging app is set up correctly
+
+Currently requires Python 3.
+
+If you find more issues with setting this up, let's see if we can add to this
+script.
+'''
+import json
+import os
+import re
+import winreg
+
+key_path = 'Software\\Mozilla\\NativeMessagingHosts\\ff2mpv'
+# Assuming current user overrides local machine.
+key_roots = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE']
+
+found_key = False
+
+for root in key_roots:
+    key = winreg.OpenKey(getattr(winreg, root), key_path)
+    try:
+        print('Checking:', root, key_path)
+        res = winreg.QueryValueEx(key, '')
+    except FileNotFoundError:
+        print('...error finding key')
+        continue
+
+    found_key = True
+    break
+
+if not found_key:
+    raise ValueError('Could not find a registry entry, aborting.')
+
+json_path = res[0]
+print('Path from registry key is:', json_path)
+if not os.path.exists(json_path):
+    raise ValueError('JSON file does not exist:', json_path)
+
+try:
+    bat_data = json.load(open(json_path, 'r'))
+except json.decoder.JSONDecodeError:
+    raise ValueError('Parsing error. Is {} a JSON file?'.format(json_path))
+
+bat_path = bat_data['path']
+print('Path from JSON is:', bat_path)
+if not os.path.exists(bat_path):
+    raise ValueError('.bat does not exist:', bat_path)
+
+py_lines = open(bat_path, 'r').readlines()
+py_path = None
+for line in py_lines:
+    if line.startswith('call python '):
+        py_path = line[12:].replace('\\\\', '\\').strip()
+
+if not py_path:
+    raise ValueError('No python script in the batch file.')
+
+print('Path from batch file is:', py_path)
+if not os.path.exists(py_path):
+    raise ValueError('Python file does not exist:', py_path)
+
+print('Looks good! Give it a try from Firefox.')

--- a/ff2mpv-windows.json
+++ b/ff2mpv-windows.json
@@ -6,4 +6,3 @@
     "allowed_extensions": ["ff2mpv@yossarian.net"]
 }
 
-

--- a/ff2mpv-windows.json
+++ b/ff2mpv-windows.json
@@ -1,0 +1,9 @@
+{
+    "name": "ff2mpv",
+    "description": "ff2mpv's native manifest",
+    "path": "ff2mpv.bat",
+    "type": "stdio",
+    "allowed_extensions": ["ff2mpv@yossarian.net"]
+}
+
+

--- a/ff2mpv.bat
+++ b/ff2mpv.bat
@@ -1,0 +1,2 @@
+@echo off
+call python ff2mpv.py


### PR DESCRIPTION
Hey! I really like your extension, and have used it on Windows for some time now. I'd like to share my setup so that the broader community can benefit. 
In this commit, I have added three files, which I will explain in a second. But first, let me explain how I setup ff2mpv on Windows. I hope this can be added to the wiki too.

1. Open the Registry Editor through the start menu. Go to `HKEY_CURRENT_USER\SOFTWARE\Mozilla\NativeMessagingHosts` and add a registry key for `ff2mpv`. The value should be the location of the ff2mpv.json file, for me that is `C:\Users\thomastay\ff2mpv\ff2mpv-windows.json`
2. (optional) using Python, check that the registry key is properly installed by running the `python3 check_config_win.py`.
That's it!

Now, I can explain the 3 files. In order to run the ff2mpv.py, you need a batch script to run the python file, this is provided. It is important that it is a batch script; Powershell will not work. The ff2mpv.json file had to be changed to run the batch script instead, I have added a new file that will not override the current ff2mpv.json file. Lastly, the checker is modified from the Mozilla examples, and is there to validate that the user has edited the registry correctly.

Of course, this means that Python must be installed on the machine, but I think that is a given :)