### PR TITLE
Add access key for context menu

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -11,7 +11,7 @@ function ff2mpv(url) {
 
 browser.contextMenus.create({
     id: "ff2mpv",
-    title: "Play in MPV",
+    title: "Play in MPV"  + ( !!browser.contextMenus.getTargetElement ? " (&W)" : "" ),
     contexts: ["link", "image", "video", "audio", "selection", "frame"]
 });
 


### PR DESCRIPTION
It's very convenient to be able to access the context menu item "Play in MPV"  from the keyboard. As long as there is a single context menu item added by the extension, it shouldn't be an issue.

The question is, which key should we use? Depending on the context, different keys are available, but we need one that's not occupied by any of them. 'W' seems vacant for now. I find it convenient because it's close to the left home row while the right hand is placed on the mouse.

As access keys were introduced in Firefox 63, we only apply ours if we're not on an older version.