### PR TITLE
Start video in mpv at the time the video was at in the browser

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -2,11 +2,11 @@ function onError(error) {
     console.log(`${error}`);
 }
 
-function ff2mpv(url) {
-    browser.tabs.executeScript({
-        code: "video = document.getElementsByTagName('video');video[0].pause();"
-    });
-    browser.runtime.sendNativeMessage("ff2mpv", { url: url }).catch(onError);
+async function ff2mpv(url) {
+    let time = await browser.tabs.executeScript({
+        code: "video = document.getElementsByTagName('video');video[0].pause();video[0].currentTime"
+    }) || 0;
+    browser.runtime.sendNativeMessage("ff2mpv", { url, time }).catch(onError);
 }
 
 browser.contextMenus.create({

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -8,9 +8,6 @@ async function ff2mpv(url, direct) {
         time = await browser.tabs.executeScript({
             code: "video = document.getElementsByTagName('video');video[0].pause();video[0].currentTime"
         });
-    } else {
-        // Try to find time in a url parameter
-        time = parseInt(url.match(/(?<=\W(t|time)=)\d+/)?.[0], 10)
     }
     browser.runtime.sendNativeMessage("ff2mpv", time ? { url, time } : { url }).catch(onError);
 }

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -11,8 +11,9 @@ import subprocess
 def main():
     message = get_message()
     url = message.get("url")
+    time = message.get("time") or 0
 
-    args = ["mpv", "--no-terminal", "--", url]
+    args = ["mpv", "--no-terminal", f"--start={time}", "--", url]
 
     kwargs = {}
     # https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -11,9 +11,9 @@ import subprocess
 def main():
     message = get_message()
     url = message.get("url")
-    time = message.get("time") or 0
+    time = message.get("time")
 
-    args = ["mpv", "--no-terminal", f"--start={time}", "--", url]
+    args = ["mpv", "--no-terminal", f"--start={time}", "--", url] if time else ["mpv", "--no-terminal", "--", url]
 
     kwargs = {}
     # https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -13,7 +13,11 @@ def main():
     url = message.get("url")
     time = message.get("time")
 
-    args = ["mpv", "--no-terminal", f"--start={time}", "--", url] if time else ["mpv", "--no-terminal", "--", url]
+    extra_args = []
+    if time is not None:
+        extra_args.append(f"--start={time}")
+
+    args = ["mpv", "--no-terminal", *extra_args, "--", url]
 
     kwargs = {}
     # https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app


### PR DESCRIPTION
Closes #56

Also I don't fully understand how `browser.tabs.executeScript` works from the mozilla docs, I think currently if a video is playing and the context menu item is used on a link it'll play that url with the time of the video in the current tab, maybe an argument can be added to the `ff2mpv` function to check that.

(I couldn't get the messaging to work between the extention and the python script, and I can't modify the extention because it is signed, so it's currently untested and might not work)