### PR TITLE
Small PR for Error Feedback using Alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         ruby:
           - "2.5"
           - "2.6"
-          # - "2.7"
+          - "2.7"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: rubocop
@@ -30,14 +30,14 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: deps

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -1,12 +1,26 @@
 function onError(error) {
     console.log(`${error}`);
+    // Response to user tried to open when json file and config isn't there
+    var msg = "alert(`Seems integration is failed : "+error+"`)";
+    browser.tabs.executeScript({
+        code: msg
+    }); 
 }
 
 function ff2mpv(url) {
     browser.tabs.executeScript({
         code: "video = document.getElementsByTagName('video');video[0].pause();"
     });
-    browser.runtime.sendNativeMessage("ff2mpv", { url: url }).catch(onError);
+    browser.runtime.sendNativeMessage("ff2mpv", { url: url }, function(r) {
+        console.log(r);
+        if (r != "ok") {
+            // If failed, print terminal failure message
+            var msg = "alert(`"+r+"`)";
+            browser.tabs.executeScript({
+                code: msg
+            }); 
+        }
+    }).catch(onError);
 }
 
 async function getOS() {

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -9,6 +9,9 @@ function ff2mpv(url) {
     browser.runtime.sendNativeMessage("ff2mpv", { url: url }).catch(onError);
 }
 
+// define the platform variable to check the platform Info
+var platform = browser.runtime.getPlatformInfo();
+
 // Make check on platform
 platform.then(function(i) {
   var os = i.os;

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -9,24 +9,30 @@ function ff2mpv(url) {
     browser.runtime.sendNativeMessage("ff2mpv", { url: url }).catch(onError);
 }
 
-browser.contextMenus.create({
-    id: "ff2mpv",
-    title: "Play in MPV"  + ( !!browser.contextMenus.getTargetElement ? " (&V)" : "" ),
-    contexts: ["link", "image", "video", "audio", "selection", "frame"]
-});
-
-browser.contextMenus.onClicked.addListener((info, tab) => {
-    switch (info.menuItemId) {
-        case "ff2mpv":
-            /* These should be mutually exclusive, but,
-               if they aren't, this is a reasonable priority.
-            */
-            url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
-            if (url) ff2mpv(url);
-            break;
-    }
-});
-
-browser.browserAction.onClicked.addListener((tab) => {
-    ff2mpv(tab.url);
+// Make check on platform
+platform.then(function(i) {
+  var os = i.os;
+  // if it's windows then use mnemonics V, if not use W as default
+  var contextMenu = os == "win" ? "&V" : "V (&W)";
+  browser.contextMenus.create({
+      id: "ff2mpv",
+      title: "Play in MP"  + ( !!browser.contextMenus.getTargetElement ? contextMenu : "" ),
+      contexts: ["link", "image", "video", "audio", "selection", "frame"]
+  });
+  
+  browser.contextMenus.onClicked.addListener((info, tab) => {
+      switch (info.menuItemId) {
+          case "ff2mpv":
+              /* These should be mutually exclusive, but,
+                 if they aren't, this is a reasonable priority.
+              */
+              url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
+              if (url) ff2mpv(url);
+              break;
+      }
+  });
+  
+  browser.browserAction.onClicked.addListener((tab) => {
+      ff2mpv(tab.url);
+  });
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -11,7 +11,7 @@ function ff2mpv(url) {
 
 browser.contextMenus.create({
     id: "ff2mpv",
-    title: "Play in MPV"  + ( !!browser.contextMenus.getTargetElement ? " (&W)" : "" ),
+    title: "Play in MPV"  + ( !!browser.contextMenus.getTargetElement ? " (&V)" : "" ),
     contexts: ["link", "image", "video", "audio", "selection", "frame"]
 });
 

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -12,7 +12,7 @@ def main():
     message = get_message()
     url = message.get("url")
 
-    args = ["mpv", "--no-terminal", "--", url]
+    args = ["mpv", "--", url] # need to remove terminal because it need to capture the output of yt-dlp
 
     kwargs = {}
     # https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app
@@ -30,11 +30,14 @@ def main():
         path = os.environ.get("PATH")
         os.environ["PATH"] = f"/usr/local/bin:{path}"
 
-    subprocess.Popen(args, **kwargs)
-
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,**kwargs)
+    pOut, pErr = process.communicate() # @see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate
     # Need to respond something to avoid "Error: An unexpected error occurred"
     # in Browser Console.
-    send_message("ok")
+    if "ERROR" not in str(pOut) :    
+        send_message("ok")
+    else :
+        send_message(pOut.decode("utf-8"))
 
 
 # https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#App_side


### PR DESCRIPTION
Hello @woodruffw, I hope this help a little, I tried to implement the error feedback, so people can see the terminal output in alert() on respected page, I hope it simplify the option as I don't think we need notification permission (?) because as far as the user on the page, it will see the alert, just as far as the user doesn't dismiss it. 

--no-terminal flag as no effect on windows, so I dismiss it, as https://github.com/yt-dlp/yt-dlp return error doesn't shown on pOut (stdout), when this flags on, so I hope this doesn't affect Linux or *nix/Darwin/macOS box (hopefully)

This method employ https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate 

Related to #40 

**Note** : I only test this on Windows 10 21H2 for now, with Python 3.8 (as Python 3.6, 3.7 failed to run, so best to assume 3.8 is the minimum requirement). I will tried to test on my Linux box next week on Office.   

Example : 
![image](https://user-images.githubusercontent.com/2817332/148580964-39515c67-f9cc-445d-ad05-f35d4da1f6ee.png)
