### PR TITLE
fix: fix encoding issue on ff2mpv.bat

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -155,9 +155,8 @@ function install () {
   }
 
   # Batch script update
-  $bat = "@echo off
-  call $python ff2mpv.py"
-  $bat > "./ff2mpv.bat"
+  $bat = "@echo off`ncall $python ff2mpv.py"
+  [System.IO.File]::WriteAllLines("ff2mpv.bat", $bat)
 
   # JSON manipulation if using chromium based browser
   if ($browser -ne "firefox") {


### PR DESCRIPTION
Sometimes redirecting the string as a file can cause issues with the encoding of the file which cause issues at running it or when it is called from the NativeMassagingHosts. Looks like `WriteAllLines` method does not have that issue.