### PR TITLE
fix: Use absolute path to update ff2mpv.bat file

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -156,7 +156,7 @@ function install () {
 
   # Batch script update
   $bat = "@echo off`ncall $python ff2mpv.py"
-  [System.IO.File]::WriteAllLines("ff2mpv.bat", $bat)
+  [System.IO.File]::WriteAllLines("$PWD\ff2mpv.bat", $bat)
 
   # JSON manipulation if using chromium based browser
   if ($browser -ne "firefox") {


### PR DESCRIPTION
I was trying to reproduce #85 on a fresh Windows install and I noticed that updating `ff2mpv.bat` was not working. Curiously the backend worked with Firefox using `python` but not on edge and chrome (those two required to update the command to `py`).

The reason seems to be that .NET may have a different working directory than powershell ([more info](https://stackoverflow.com/questions/69682081/powershell-system-io-filewritealllines-not-working)). This change should ensure that it uses the right path to update the file.