### PR TITLE
Add Rust native host implementation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ macOS: https://github.com/woodruffw/ff2mpv/wiki/Installation-on-macOS
 
 Windows: https://github.com/woodruffw/ff2mpv/wiki/Installation-on-Windows
 
+[A Rust version of the native client is also available](https://github.com/ryze312/ff2mpv-rust).
 [A Go version of the native client is also available](https://git.clsr.net/util/ff2mpv-go/).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ macOS: https://github.com/woodruffw/ff2mpv/wiki/Installation-on-macOS
 
 Windows: https://github.com/woodruffw/ff2mpv/wiki/Installation-on-Windows
 
-[A Rust version of the native client is also available](https://github.com/ryze312/ff2mpv-rust).
-[A Go version of the native client is also available](https://git.clsr.net/util/ff2mpv-go/).
+The following community-maintained native clients are also available:
+
+* [Rust](https://github.com/ryze312/ff2mpv-rust)
+* [Go](https://git.clsr.net/util/ff2mpv-go/)
 
 ## License
 


### PR DESCRIPTION
Made native host in Rust. I think it would be useful to include a link to it alongside the Go implementation.