### PR TITLE
feat: Update powershell script to support custom-firefox and librewolf

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,10 +7,26 @@ param (
 $browser = $args[0]
 $custom_hkcu = $args[1]
 
+# Repository location
+$repository_path = $PSScriptRoot
 # Hold registry path in HKEY_CURRENT_USER
 $hkcu_dest = ""
 # Json
-$json_path = (pwd).toString()
+$json_path = $repository_path
+# Edit json file for chromium
+$use_chromium_json = $true
+# Chrome Store Extension ID
+$chrome_extension_id = "chrome-extension://ephjcajbkgplkjmelpglennepbpmdpjg/"
+# List of browsers that this script support
+$supported_browsers = @(
+  'firefox',
+  'librewolf',
+  'chromium',
+  'chrome',
+  'edge',
+  'custom-chromium',
+  'custom-firefox'
+)
 
 function testCommand {
   Param ($command)
@@ -23,77 +39,104 @@ function testCommand {
 }
 
 function help {
-  $pad = "    "
-  Write-Output ""
-  Write-Output "${pad}Installing script for ff2mpv"
-  Write-Output "${pad}Command syntax: >.\install.ps1 [browser] [registry_path] [-uninstall] [-help]"
-  Write-Output ""
-  Write-Output ""
-  Write-Output "${pad}Arguments:"
-  Write-Output ""
-  Write-Output "${pad}browser           The name of the browser to install"
-  Write-Output "${pad}                  Valid options: firefox, chrome, chromium, edge, custom"
-  Write-Output ""
-  Write-Output "${pad}registry_path     The path in the registry for the NativeMessagingHost directory"
-  Write-Output "${pad}                  Only needed if browser is `"custom`""
-  Write-Output ""
-  Write-Output ""
-  Write-Output "${pad}Flags:"
-  Write-Output ""
-  Write-Output "${pad}-uninstall        Uninstall the registry key value for the given browser"
-  Write-Output ""
-  Write-Output "${pad}-help             Show this message"
-  Write-Output ""
+  Write-Output "
+    Installing script for ff2mpv
+    Command syntax: > .\install.ps1 [browser] [registry_path] [-uninstall] [-help]
+
+
+    Arguments:
+
+    browser:          The name of the browser to install
+                      Valid options: firefox, chrome, chromium, edge, custom
+
+    registry_path:    The path in the registry for the NativeMessagingHost directory
+                      Only needed if browser is `"custom-chromium`" or `"custom-firefox`"
+
+
+    Flags:
+
+    -uninstall        Uninstall the registry key value for the given browser
+
+    -help             Show this message
+    "
 }
 
 function select_browser () {
-  switch ($browser) {
-    "firefox" {
+  switch -Regex ($browser) {
+    "^(firefox|librewolf)$" {
       $script:hkcu_dest = "Registry::HKEY_CURRENT_USER\SOFTWARE\Mozilla"
       $script:json_path = "$script:json_path\ff2mpv-windows.json"
+      $script:use_chromium_json = $false
+      break
     }
-    "chrome" {
+    "^chrome$" {
       $script:hkcu_dest = "Registry::HKEY_CURRENT_USER\SOFTWARE\Google\Chrome"
       $script:json_path = "$script:json_path\ff2mpv-windows-chrome.json"
+      break
     }
-    "chromium" {
+    "^chromium$" {
       $script:hkcu_dest = "Registry::HKEY_CURRENT_USER\SOFTWARE\Chromium"
       $script:json_path = "$script:json_path\ff2mpv-windows-chrome.json"
+      break
     }
-    "edge" {
+    "^edge$" {
       $script:hkcu_dest = "Registry::HKEY_CURRENT_USER\SOFTWARE\Microsoft\Edge"
       $script:json_path = "$script:json_path\ff2mpv-windows-chrome.json"
+      break
     }
-    "custom" {
+    "^custom-(chromium|firefox)$" {
       if (-not $custom_hkcu) {
         Write-Output "Please enter a path for HKEY_CURRENT_USER"
         $new_path = Read-Host -Prompt "> "
+        $new_path = $new_path.Trim()
+        if ($new_path -like 'exit*') {
+          exit 0
+        } elseif ($new_path -like 'help*') {
+          help
+          exit 0
+        }
         $script:custom_hkcu = $new_path
         select_browser
+        break
       } else {
         $script:hkcu_dest = $custom_hkcu.replace("/", "\")
-        $script:json_path = "$script:json_path\ff2mpv-windows-$($script:hkcu_dest.split("\")[-1]).json"
+        if (-not $script:hkcu_dest.StartsWith('Registry::','CurrentCultureIgnoreCase')) {
+          $script:hkcu_dest = "Registry::$script:hkcu_dest"
+        }
       }
     }
-    "help" {
+    "^custom-chromium$" {
+      $script:json_path = "$script:json_path\ff2mpv-windows-$($script:hkcu_dest.split("\")[-1]).json"
+      break
+    }
+    "^custom-firefox$" {
+      $script:use_chromium_json = $false
+      $script:json_path = "$script:json_path\ff2mpv-windows-$($script:hkcu_dest.split("\")[-1]).json"
+      break
+    }
+    "^help$" {
       help
       exit 0
     }
-    "exit" {
+    "^exit$" {
       exit 0
     }
     default {
       Write-Output ""
       Write-Output "Invalid option. Please select a valid browser:"
-      Write-Output "`"chrome`", `"firefox`", `"chromium`", `"edge`"`, or"
-      Write-Output "`"custom`" and provide the path in the registry as a second argument"
-      Write-Output "E.g. > `"custom`" `"Registry::HKEY_CURRENT_USER\SOFTWARE\Google\Chrome`" For Chrome"
+      $supported_browsers | % { Write-Output $_ }
+      Write-Output ""
+      Write-Output "For custom options provide the path in the registry as a second argument"
+      Write-Output "E.g. > `"custom-chromium`" `"Registry::HKEY_CURRENT_USER\SOFTWARE\Google\Chrome`" for Chrome"
       Write-Output ""
       Write-Output "Enter `"help`" to display more information or `"exit`" to quit."
-      Write-Output ""
+
       $new_input = Read-Host -Prompt "> "
-      $script:browser = $new_input.split()[0]
-      $script:custom_hkcu = $new_input.split()[1]
+      $new_input = $new_input.Trim()
+      $brow, $hkcu = $new_input -split '\s+'
+
+      $script:browser = $brow
+      $script:custom_hkcu = $hkcu
       select_browser
     }
   }
@@ -102,11 +145,22 @@ function select_browser () {
 function install () {
   select_browser
   $registry_dest = "$hkcu_dest\NativeMessagingHosts"
+  $ff2mpv = "$registry_dest\ff2mpv"
+
+  # LibreWolf has its own entry in registry: HKEY_CURRENT_USER\Software\LibreWolf.
+  # However it reads the entries for Mozilla as Firefox does and ignores the ones in LibreWolf.
+  # Check if Mozilla entry exist or add it if not.
+  if (($browser -eq 'librewolf') -and -not (Test-Path "$hkcu_dest")) {
+    Write-Output ""
+    Write-Output "Creating `"$hkcu_dest`""
+    Write-Output "entry in registry for librewolf"
+    New-Item -Path "$hkcu_dest"
+  }
 
   # Test if the browser path entry exist 
   if (-not (Test-Path $hkcu_dest)) {
     Write-Output ""
-    Write-Output "Please start your browser at least once to generate the required directories"
+    Write-Output "Please start your browser at least once to generate the required registry entries"
     exit 1
   }
 
@@ -118,24 +172,24 @@ function install () {
   }
 
   # Handle ff2mpv registry
-  if (Test-Path "$registry_dest\ff2mpv") {
-    $current = (Get-ItemProperty "$registry_dest\ff2mpv")."(default)" 
-    if ($current -eq $json_path) {
+  if (Test-Path "$ff2mpv") {
+    $current = (Get-ItemProperty "$ff2mpv")."(default)" 
+    if ($current -eq "$json_path") {
       Write-Output ""
       Write-Output "Registry key already exists for browser `"$browser`""
     } else {
       Write-Output ""
       Write-Output "Registry key found with value:"
-      Write-Output $current
+      Write-Output "$current"
       Write-Output "Overriding with: $json_path"
-      New-Item -Path "$registry_dest\ff2mpv" -value $json_path -Force
+      New-Item -Path "$ff2mpv" -Value "$json_path" -Force
     }
   } else {
     Write-Output ""
     Write-Output "Creating registry key in:"
-    Write-Output "$registry_dest\ff2mpv"
+    Write-Output "$ff2mpv"
     Write-Output "with value: $json_path"
-    New-Item -Path "$registry_dest\ff2mpv" -value $json_path
+    New-Item -Path "$ff2mpv" -Value "$json_path"
   }
 
   # Detect Python Launcher
@@ -149,6 +203,7 @@ function install () {
   } elseif (testCommand python) {
     $python = "python"
   } else {
+    Write-Output ""
     Write-Output "Python not found!"
     Write-Output "Please install python and add it to your path to continue..."
     exit 1
@@ -156,18 +211,22 @@ function install () {
 
   # Batch script update
   $bat = "@echo off`ncall $python ff2mpv.py"
-  [System.IO.File]::WriteAllLines("$PWD\ff2mpv.bat", $bat)
+  [System.IO.File]::WriteAllLines("$repository_path\ff2mpv.bat", $bat)
 
   # JSON manipulation if using chromium based browser
-  if ($browser -ne "firefox") {
+  if ($use_chromium_json) {
     Write-Output ""
     Write-Output "Creating JSON for $browser browser..."
-    $json_file = Get-Content "./ff2mpv-windows.json" -raw | ConvertFrom-Json
+    $json_file = Get-Content "$repository_path\ff2mpv-windows.json" -Raw | ConvertFrom-Json
     $json_file.PSObject.Properties.Remove('allowed_extensions')
     $tmp_list = New-Object System.Collections.ArrayList
-    $_ = $tmp_list.add("chrome-extension://ephjcajbkgplkjmelpglennepbpmdpjg/")
-    $json_file | Add-Member -MemberType NoteProperty -Name "allowed_origins" -value $tmp_list
-    $json_file | ConvertTo-Json -depth 32 | Set-Content $json_path
+    $_ = $tmp_list.add($chrome_extension_id)
+    $json_file | Add-Member -MemberType NoteProperty -Name "allowed_origins" -Value $tmp_list
+    $json_file | ConvertTo-Json -Depth 32 | Set-Content "$json_path"
+  } elseif ($browser -eq 'custom-firefox') {
+    Write-Output ""
+    Write-Output "Creating JSON for $browser browser..."
+    Copy-Item "$repository_path\ff2mpv-windows.json" -Destination "$json_path"
   }
 
   # Show warning if mpv cannot be found in path
@@ -184,12 +243,13 @@ function install () {
 function uninstall () {
   select_browser
   $registry_dest = "$hkcu_dest\NativeMessagingHosts"
+  $ff2mpv = "$registry_dest\ff2mpv"
 
   # Test if the browser path entry exist 
-  if (Test-Path "$registry_dest\ff2mpv") {
+  if (Test-Path "$ff2mpv") {
     Write-Output ""
     Write-Output "Removing registry key..."
-    Remove-Item "$registry_dest\ff2mpv"
+    Remove-Item "$ff2mpv"
     Write-Output "Remove successful"
   } else {
     Write-Output ""


### PR DESCRIPTION
A PR to enhance the install script for windows.

- Added the option to install `custom-firefox`. Main difference is that chromium-based browsers do not support 'allowed_extensions' entry in the json file but need 'allowed_origins' array instead (with the Chrome Store Id).
- Added support for LibreWolf (tested chocolatey version 109.0.1.2)
- Added support for `exit` and `help` in all the prompts
- Added ability to enter a registry path without adding the `Registry::` prefix.