### PR TITLE
Include the prefix /opt/homebrew/bin in the PATH for installations that were performed for arch arm64

### DIFF
--- a/ff2mpv
+++ b/ff2mpv
@@ -18,7 +18,7 @@ args.push(*options)
 # from, say, Firefox. The real fix is to modify `launchd.conf`, but that's
 # invasive and maybe not what users want in the general case.
 # Hence this nasty hack.
-ENV["PATH"] = "/usr/local/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
+ENV["PATH"] = "/usr/local/bin:/opt/homebrew/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
 
 pid = spawn "mpv", *args, "--", url, in: :close, out: "/dev/null", err: "/dev/null"
 

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -29,7 +29,7 @@ def main():
     # Hence this nasty hack.
     if platform.system() == "Darwin":
         path = os.environ.get("PATH")
-        os.environ["PATH"] = f"/usr/local/bin:{path}"
+        os.environ["PATH"] = f"/usr/local/bin:/opt/homebrew/bin:{path}"
 
     subprocess.Popen(args, **kwargs)
 


### PR DESCRIPTION
I think for some reasons, previous Mac Silicons had the homebrew still installing applications under `/usr/local/bin`.
When not installed under Rosetta, it will default the location to `/opt/homebrew` according to [the documentation](https://docs.brew.sh/FAQ#why-is-the-default-installation-prefix-opthomebrew-on-apple-silicon).

ff2mpv was not working for me until I added this change to the PATH.

I am not used to contribute a lot to open source, so let me know if there are any changes that are desired please.