### PR TITLE
feat: Add API for external extensions to call ff2mpv

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -4,6 +4,8 @@ function onError(error) {
   console.log(`${error}`);
 }
 
+const OPEN_VIDEO = 'openVideo';
+
 function ff2mpv(url, options = []) {
   browser.tabs.executeScript({
     code: "video = document.getElementsByTagName('video');video[0].pause();"
@@ -95,5 +97,26 @@ getOS().then(async (os) => {
 
   browser.browserAction.onClicked.addListener((tab) => {
     ff2mpv(tab.url);
+  });
+
+  // Messages sent with browser.runtime.sendMessage (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) from external applications will be handle here.
+  // ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
+  browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+    if (!request) {
+      console.wanr('No request in external message');
+      return;
+    }
+
+    const { type, url } = request;
+    console.info('Request from:', sender);
+
+    switch (type) {
+      case OPEN_VIDEO:
+        ff2mpv(url);
+        return sendResponse('ok');
+      default:
+        console.warn('No handler for external type:', type);
+        return;
+    }
   });
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -103,7 +103,7 @@ getOS().then(async (os) => {
   // ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
   browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
     if (!request) {
-      console.wanr('No request in external message');
+      console.warn('No request in external message');
       return;
     }
 

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -108,7 +108,7 @@ getOS().then(async (os) => {
     }
 
     const { type, url } = request;
-    console.info('Request from:', sender);
+    console.debug('Request from:', sender);
 
     switch (type) {
       case OPEN_VIDEO:


### PR DESCRIPTION
Add support for external extensions
=======

To allow ff2mpv extension listening to messages it needs to implement [`browser.runtime.onMessageExternal`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal).

The shape of the message is an object with two properties:
- type: The type of message to handle
- url: The url string to be used by ff2mpv

External extensions need to call ff2mpv using the extension id:

- Firefox: 'ff2mpv@yossarian.net'
- Chrome: 'ephjcajbkgplkjmelpglennepbpmdpjg'

Example of use for external extensions:
```javascript
// Firefox
browser.runtime.sendMessage('ff2mpv@yossarian.net', { type: 'openVideo', url: 'https://someurl.com' }, callback);

// Chrome
chrome.runtime.sendMessage('ephjcajbkgplkjmelpglennepbpmdpjg', { type: 'openVideo', url: 'https://someurl.com' }, callback);
```

Solves: https://github.com/woodruffw/ff2mpv/issues/112
