### PR TITLE
Fix/dynamic context menu

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -37,7 +37,7 @@ async function getOptions(id) {
       ? profile.content.filter(line => !!line)
       : [];
   } catch (error) {
-    console.debug(`Unable to get options for profile:`, id, error);
+    console.debug('Unable to get options for profile:', id, error);
     return [];
   }
 }

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -19,17 +19,27 @@ async function getOS() {
 }
 
 async function getProfiles() {
-  return (await browser.storage.sync.get('profiles'))['profiles'] || [];
+  try {
+    return (await browser.storage.sync.get('profiles'))['profiles'] || [];
+  } catch (error) {
+    console.debug('Unable to get profiles:', error);
+    return [];
+  }
 };
 
 async function getOptions(id) {
-  const profiles = await getProfiles();
-  const profile = profiles.find(pf => pf.id === id);
+  try {
+    const profiles = await getProfiles();
+    const profile = profiles.find(pf => pf.id === id);
 
-  // If profile, remove empty lines
-  return profile
-    ? profile.content.filter(line => !!line)
-    : [];
+    // If profile, remove empty lines
+    return profile
+      ? profile.content.filter(line => !!line)
+      : [];
+  } catch (error) {
+    console.debug(`Unable to get options for profile:`, id, error);
+    return [];
+  }
 }
 
 async function submenuClicked(info) {
@@ -47,7 +57,9 @@ async function submenuClicked(info) {
 
 function changeToMultiEntries() {
   // Remove single entry
-  browser.contextMenus.remove('ff2mpv');
+  try {
+    browser.contextMenus.remove('ff2mpv');
+  } catch (error) {}
 
   // Add sub context menu
   browser.contextMenus.create({
@@ -67,7 +79,9 @@ function changeToMultiEntries() {
 
 function changeToSingleEntry() {
   // Remove sub context menu
-  browser.contextMenus.remove('ff2mpv');
+  try {
+    browser.contextMenus.remove('ff2mpv');
+  } catch (error) {}
 
   // Add single entry
   browser.contextMenus.create({


### PR DESCRIPTION
I did some test on my steam deck for https://github.com/woodruffw/ff2mpv/issues/116 and I found the following error on brave browser:
![image](https://github.com/woodruffw/ff2mpv/assets/49035812/54ddc6f7-176a-4304-881d-e0d61976f34a)

It happens because on browser launch it will try to remove the `ff2mpv` context menu without it being added previously. However this didn't affect the browser to add the "Play in MPV" or "Profiles" context menu. I didn't observe any error in firefox but something similar may be happening.

I've wrapped the calls for `browser.contextMenus.remove` in a try/catch block to prevent any further issue.

Additionally I've wrapped the functions `getProfiles` and `getOptions` in try/catch blocks in case any of those caused an unexpected error.