### PR TITLE
Make path match users configurations

### DIFF
--- a/ff2mpv
+++ b/ff2mpv
@@ -18,7 +18,7 @@ args.push(*options)
 # from, say, Firefox. The real fix is to modify `launchd.conf`, but that's
 # invasive and maybe not what users want in the general case.
 # Hence this nasty hack.
-ENV["PATH"] = "/usr/local/bin:/opt/homebrew/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
+ENV["PATH"] = "/opt/homebrew/bin:/usr/local/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
 
 pid = spawn "mpv", *args, "--", url, in: :close, out: "/dev/null", err: "/dev/null"
 

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -29,7 +29,7 @@ def main():
     # Hence this nasty hack.
     if platform.system() == "Darwin":
         path = os.environ.get("PATH")
-        os.environ["PATH"] = f"/usr/local/bin:/opt/homebrew/bin:{path}"
+        os.environ["PATH"] = f"/opt/homebrew/bin:/usr/local/bin:{path}"
 
     subprocess.Popen(args, **kwargs)
 


### PR DESCRIPTION
By default homebrew always sets the system path up so that homebrew is before the system installs and /usr/local/bin installs. Without this it is possible to result in a configuration where the wrong mpv than the one the user expects is called.