### PR TITLE
Feature: Add access keys/hotkeys/mnemonics for context menu

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -4,7 +4,7 @@ const UPDATE_PROFILE = "updateProfile";
 const DELETE_PROFILE = "deleteProfile";
 const PROFILES = "profiles";
 const OPEN_VIDEO = "openVideo";
-const TITLE = "Play in MPV";
+const TITLES = ["Play in MPV", "Profiles"];
 
 function onError(error) {
   console.log(`${error}`);
@@ -21,6 +21,21 @@ function ff2mpv(url, tabId, options) {
   }
   options = options ? options : [];
   chrome.runtime.sendNativeMessage("ff2mpv", { url, options }).catch(onError);
+}
+
+async function getMnemonicTitle(title) {
+  let key = "X";
+  if (typeof browser === "object") {
+    try {
+      await chrome.runtime.sendMessage("@testpilot-containers", {}, {});
+    }
+    catch (error) {
+      if (error.message === "Could not establish connection. Receiving end does not exist.") {
+        key = "W";
+	  }
+	}
+  }
+  return `${title} (&${key})`;
 }
 
 async function getProfiles() {
@@ -67,14 +82,14 @@ async function changeToMultiEntries() {
   // Add sub context menu
   await chrome.contextMenus.create({
     id: "ff2mpv",
-    title: "Profiles",
+    title: await getMnemonicTitle(TITLES[1]),
     contexts,
   });
 
   await chrome.contextMenus.create({
     parentId: "ff2mpv",
     id: "22941114-4db3-4296-8fc2-49f178843f52",
-    title: TITLE,
+    title: await getMnemonicTitle(TITLES[0]),
     contexts,
   });
 }
@@ -85,7 +100,7 @@ async function changeToSingleEntry() {
 
   await chrome.contextMenus.create({
     id: "ff2mpv",
-    title: TITLE,
+    title: await getMnemonicTitle(TITLES[0]),
     contexts,
   });
 }

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -4,7 +4,7 @@ const UPDATE_PROFILE = "updateProfile";
 const DELETE_PROFILE = "deleteProfile";
 const PROFILES = "profiles";
 const OPEN_VIDEO = "openVideo";
-const TITLES = ["Play in MPV", "Profiles"];
+const TITLES = ["Play in MPV (&X)", "Profiles (&X)"];
 
 function onError(error) {
   console.log(`${error}`);
@@ -21,21 +21,6 @@ function ff2mpv(url, tabId, options) {
   }
   options = options ? options : [];
   chrome.runtime.sendNativeMessage("ff2mpv", { url, options }).catch(onError);
-}
-
-async function getMnemonicTitle(title) {
-  let key = "X";
-  if (typeof browser === "object") {
-    try {
-      await chrome.runtime.sendMessage("@testpilot-containers", {}, {});
-    }
-    catch (error) {
-      if (error.message === "Could not establish connection. Receiving end does not exist.") {
-        key = "W";
-	  }
-	}
-  }
-  return `${title} (&${key})`;
 }
 
 async function getProfiles() {
@@ -82,14 +67,14 @@ async function changeToMultiEntries() {
   // Add sub context menu
   await chrome.contextMenus.create({
     id: "ff2mpv",
-    title: await getMnemonicTitle(TITLES[1]),
+    title: TITLES[1],
     contexts,
   });
 
   await chrome.contextMenus.create({
     parentId: "ff2mpv",
     id: "22941114-4db3-4296-8fc2-49f178843f52",
-    title: await getMnemonicTitle(TITLES[0]),
+    title: TITLES[0],
     contexts,
   });
 }
@@ -100,7 +85,7 @@ async function changeToSingleEntry() {
 
   await chrome.contextMenus.create({
     id: "ff2mpv",
-    title: await getMnemonicTitle(TITLES[0]),
+    title: TITLES[0],
     contexts,
   });
 }


### PR DESCRIPTION
This is a reinstalment of the feature first introduced in #55, which was removed in #70.

It adds an access key (a.k.a. hotkey or mnemonic) to the context menu items created by ff2mpv.

An access key is an underlined (or otherwise highlighted) alphanumeric character in a menu item which activates that item on key press.

This is different from the extension shortcut which can be set by the user as a custom combination of keys that activates the extension action button.

Firefox will underline the specified access key for each item in context menus. Chromium does not underline the access keys, they remain hidden, albeit still functional.

Originally in #55, **W** was chosen as access key. This was later found to be in  conflict with [Firefox Multi-Account Containers addon](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/) (#64). As a temporary solution, **V** has been picked as access key on Windows (#65, #66). But the conflict is not limited to Windows. Furthermore, on Chromium, **W** is also taken by the "Open in new window" menu item for link context menus, which suggests revisiting our choice. 

These are the keys that are available by default for all the contexts for Firefox and Chromium:

|          | link    | image     | video   | audio     | selection | frame   |
|----------|---------|-----------|---------|-----------|-----------|---------|
| Firefox  | WERYUIO | WERUP     | WERY    | WERTYU    | WYUOP     | WETYUO  |
|          | AFGHJ   | ASDFHJKL  | GHJK    | SFGHJK    | DFGHJKL   | DFGJKL  |
|          | ZXCVM   | ZXCBNM    | ZXN     | ZXCN      | ZXVM      | ZXCBN   |
| Chromium | QRYUIOP | QWERTUP   | QWERTUI | QWERTYUIP | QWERTYUI  | QWETYUI |
|          | ASDFHJL | ASDFGHJKL | ASDGHJK | ASDFGHJK  | ADFGHJKL  | SDGHJKL |
|          | ZXCVBM  | ZXBM      | ZXBM    | ZXBM      | ZXBM      | ZXVBM   |

 We can see that **W** is vacant for Firefox if Multi-Account Containers addon is **not** installed. This is also my preferred key as explained in #55.

However, we need to check if it's installed. To avoid using `maintenance.get()` and requiring another permission (as established in #64), we can try to send an external message to that addon. If this raises an exception saying the connection couldn't be established, it means the addon is not installed and we can safely apply **W** as access key. This approach can be used to detect possible conflicts with other extensions in future.

If the Multi-Account Containers addon **is** installed, or we are on Chromium, then we use **X**. It's not ideal, but it's either that or **Z** if we're going to use the same key for all browsers.

An alternative and simpler approach would be to just use **X** everywhere and not care for any conflicts.