### PR TITLE
feat: Add support for options using native messaging

### DIFF
--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -158,16 +158,24 @@ chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => 
     return;
   }
 
-  const { type, url, options } = request;
+  const { type, url, profileId } = request;
   console.debug("Request from:", sender);
 
   const tabId = null;
 
   switch (type) {
     case OPEN_VIDEO:
+    let optionsPromise;
+      if (profileId) {
+        optionsPromise = getOptions(profileId); 
+      } else {
+        optionsPromise = Promise.resolve([]); 
+      }
+      optionsPromise.then((options) => {
       ff2mpv(url, tabId, options);
       return sendResponse("ok");
-          break;
+      });
+      break;
     case GET_PROFILES:
       getProfiles().then((profiles) => {
         sendResponse(profiles); 

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -165,25 +165,25 @@ chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => 
 
   switch (type) {
     case OPEN_VIDEO:
-    let optionsPromise;
-      if (profileId) {
-        optionsPromise = getOptions(profileId); 
-      } else {
-        optionsPromise = Promise.resolve([]); 
-      }
-      optionsPromise.then((options) => {
-      ff2mpv(url, tabId, options);
-      return sendResponse("ok");
-      });
-      break;
-    case GET_PROFILES:
-      getProfiles().then((profiles) => {
-        sendResponse(profiles); 
-      });
-      return true;
-    default:
-      console.warn("No handler for external type:", type);
-      return sendResponse("failure");
+        let optionsPromise;
+          if (profileId) {
+            optionsPromise = getOptions(profileId); 
+          } else {
+            optionsPromise = Promise.resolve([]); 
+          }
+          optionsPromise.then((options) => {
+            ff2mpv(url, tabId, options);
+            return sendResponse("ok");
+          });
+          break;
+        case GET_PROFILES:
+          getProfiles().then((profiles) => {
+            sendResponse(profiles); 
+          });
+          return true;
+        default:
+          console.warn("No handler for external type:", type);
+          return sendResponse("failure");
   }
 });
 

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -164,7 +164,7 @@ chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => 
 
   switch (type) {
     case OPEN_VIDEO:
-      ff2mpv(url, tabId, [options]);
+      ff2mpv(url, tabId, options);
       return sendResponse("ok");
     default:
       console.warn("No handler for external type:", type);

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -3,6 +3,7 @@ const CREATE_PROFILE = "createProfile";
 const UPDATE_PROFILE = "updateProfile";
 const DELETE_PROFILE = "deleteProfile";
 const PROFILES = "profiles";
+const GET_PROFILES = "getProfiles";
 const OPEN_VIDEO = "openVideo";
 const TITLE = "Play in MPV";
 
@@ -166,6 +167,12 @@ chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => 
     case OPEN_VIDEO:
       ff2mpv(url, tabId, options);
       return sendResponse("ok");
+          break;
+    case GET_PROFILES:
+      getProfiles().then((profiles) => {
+        sendResponse(profiles); 
+      });
+      return true;
     default:
       console.warn("No handler for external type:", type);
       return sendResponse("failure");

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -157,12 +157,14 @@ chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => 
     return;
   }
 
-  const { type, url } = request;
+  const { type, url, options } = request;
   console.debug("Request from:", sender);
+
+  const tabId = null;
 
   switch (type) {
     case OPEN_VIDEO:
-      ff2mpv(url);
+      ff2mpv(url, tabId, [options]);
       return sendResponse("ok");
     default:
       console.warn("No handler for external type:", type);


### PR DESCRIPTION
An expansion to [woodruffw/ff2mpv#113](https://github.com/woodruffw/ff2mpv/pull/113), to send options through native messaging.

As referenced in [gdh1995/vimium-c/issues#1077](https://github.com/gdh1995/vimium-c/issues/1077#issuecomment-1936979906)

Example of use using JS:
```js
// Firefox
browser.runtime.sendMessage('ff2mpv@yossarian.net', { type: 'openVideo', url: 'https://someurl.com', options: '--ytdl-format=bestaudio[tbr<=?388]' })
```
Using vimium-c:
1.Add to `Custom key mappings`:
```
map <v-ff2mpv> sendToExtension id="ff2mpv@yossarian.net" raw
map vvv LinkHints.activateOpenUrl keyword="_opus"
```
2. Add to `Custom search engines`:
```
_opus: vimium://run1/ff2mpv#data={"type":"openVideo","url":"$s","options":"--ytdl-format=bestaudio[tbr<=?388]"}
```
This is very useful, as you can now open different video resolutions using various key mappings.  

Note: Currently can only send one option, i couldn't find a way to send multiple options. Hopefully someone can help with this.