### PR TITLE
fix: Update deprecated MDN URLs to new format

### DIFF
--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -38,7 +38,7 @@ def main():
     send_message("ok")
 
 
-# https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#App_side
+# https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#App_side
 def get_message():
     raw_length = sys.stdin.buffer.read(4)
     if not raw_length:


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. Old URLs redirect but are stale.

This PR updates:
- `/en-US/Add-ons/WebExtensions/Native_messaging` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging`

See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*