### PR TITLE
fix: Update deprecated MDN URLs to new format

### DIFF
--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -38,7 +38,7 @@ def main():
     send_message("ok")
 
 
-# https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#App_side
+# https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging
 def get_message():
     raw_length = sys.stdin.buffer.read(4)
     if not raw_length:


### PR DESCRIPTION
Updates deprecated MDN URLs to new format.

- Removed anchor from URL where no replacement anchor exists (per maintainer feedback on #144)

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*